### PR TITLE
Corrected a typo in Debian markdown link (line 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 README
 ======
 
-[Debian](https:www.debian.org) packages, maintains and distributes many
+[Debian](https://www.debian.org) packages, maintains and distributes many
 projects developed using GitHub.  This account was created to facilitate
 push/pull interactions with the upstream developers of such projects.  If
 you maintain a package whose upstream developers use GitHub, please feel


### PR DESCRIPTION
A typo in the 4th line
 `[Debian](https:www.debian.org)` causes user to be directed to https://github.com/Debian/www.debian.org instead.
Corrected https:www.debian.org to https://www.debian.org